### PR TITLE
garotm - Fix the FastAPI version to work with Dependabot updates.

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,7 +9,7 @@ google-api-python-client>=2.0.0
 pyjwt==2.10.*
 requests==2.32.*
 python-dateutil==2.9.*
-fastapi==0.104.1
+fastapi==0.115.6
 starlette==0.40.0
 pydantic==2.4.2
 python-jose[cryptography]==3.3.0


### PR DESCRIPTION
https://github.com/fleXRPL/RunOn/issues/53#issuecomment-2566692906

```bash
ERROR: Cannot install -r requirements.txt (line 12) and starlette==0.40.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested starlette==0.40.0
    fastapi 0.104.1 depends on starlette<0.28.0 and >=0.27.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```

Which references https://github.com/fleXRPL/RunOn/pull/52