### PR TITLE
feature/ci-path-filtering - complete.

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,10 +4,12 @@ on:
     branches: [ main, mvp-android ]
     paths:
       - 'android/**'
+      - '.github/workflows/android.yml'
   pull_request:
     branches: [ main ]
     paths:
       - 'android/**'
+      - '.github/workflows/android.yml'
 
 jobs:
   android-build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,16 @@ name: Build and Test
 on:
   push:
     branches: [ main, mvp ]
+    paths:
+      - 'backend/**'
+      - '.github/workflows/build.yml'
+      - 'requirements*.txt'
   pull_request:
     branches: [ main, mvp ]
+    paths:
+      - 'backend/**'
+      - '.github/workflows/build.yml'
+      - 'requirements*.txt'
 
 jobs:
   test:


### PR DESCRIPTION
Thank you! Yes, the path filtering in the workflow configuration is a deliberate optimization to:

1. Only run CI when relevant files change:
```yaml
# ios
paths:
  - 'ios/**'                     # Only when iOS code changes
  - '.github/workflows/ios.yml'  # Or when the workflow itself changes

# android
paths:
  - 'android/**'                     # Only when android code changes
  - '.github/workflows/android.yml'  # Or when the workflow itself changes

# python
paths:
  - 'backend/**'                     # Only when python code changes
  - '.github/workflows/build.yml'    # Or when the workflow itself changes
  - 'requirements*.txt'              # Or when the package requirements change
```

2. Save GitHub Actions minutes by not running unnecessary builds
3. Speed up PR merges by only running relevant checks

This is particularly useful in a monorepo structure like RunOn where we have:
- iOS frontend
- Backend Python code
- Android code (future)
- Infrastructure code

Each component has its specific workflow that only triggers when relevant files change. This way:
- Backend changes don't trigger iOS builds
- iOS changes don't trigger backend tests
- Each component can be developed independently
- CI/CD resources are used efficiently