### PR TITLE
securit/dependabot - Remove Unused python-jose Dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,7 +12,6 @@ python-dateutil==2.9.*
 fastapi==0.115.6
 starlette==0.40.0
 pydantic==2.4.2
-python-jose[cryptography]==3.3.0
 python-multipart==0.0.20
 python-dotenv>=0.19.0
 


### PR DESCRIPTION
# Remove Unused python-jose Dependency

## Changes
- Removed `python-jose[cryptography]==3.3.0` from `requirements.txt`

## Justification
- The package was unused in our codebase
- All authentication is handled through Google's official OAuth2 libraries:
  - `google-auth`
  - `google-auth-oauthlib`
  - `google-auth-httplib2`
- Removing this dependency resolves security alert #5 regarding algorithm confusion with OpenSSH ECDSA keys

## Testing
- ✅ All 53 tests passing
- ✅ Local development environment working correctly
- ✅ Google OAuth authentication functioning as expected

## Security Impact
- Reduces attack surface by removing unused dependency
- Resolves Dependabot security alert #5

[Closes #5](https://github.com/fleXRPL/RunOn/security/dependabot/5)
[Closes #6](https://github.com/fleXRPL/RunOn/security/dependabot/6)

![image](https://github.com/user-attachments/assets/97dae26d-17ea-472b-8593-5f1ba54cb2fd)

![image](https://github.com/user-attachments/assets/5932396b-5f25-4593-b982-afc45eacfb06)

